### PR TITLE
JO - PRODUCT-17353 - add ability to get producers and check compatibility with consumers

### DIFF
--- a/lib/avro_contract_testing/producer.rb
+++ b/lib/avro_contract_testing/producer.rb
@@ -3,7 +3,7 @@
 require 'avro_turf'
 
 module AvroContractTesting
-  class Consumer
+  class Producer
     attr_reader :application_name, :schema
 
     def initialize(application_name:, schema:)
@@ -11,9 +11,9 @@ module AvroContractTesting
       @schema = Avro::Schema.parse(schema)
     end
 
-    def compatible?(producer_schema)
-      writer_schema = Avro::Schema.parse(producer_schema)
-      Avro::SchemaCompatibility.can_read?(writer_schema, schema)
+    def compatible?(consumer_schema)
+      reader_schema = Avro::Schema.parse(consumer_schema)
+      Avro::SchemaCompatibility.can_read?(schema, reader_schema)
     end
   end
 end

--- a/spec/avro_contract_testing/consumer_spec.rb
+++ b/spec/avro_contract_testing/consumer_spec.rb
@@ -4,7 +4,7 @@ require 'avro_contract_testing/consumer'
 
 describe AvroContractTesting::Consumer do
   describe '#compatible?' do
-    subject(:consumer) { described_class.new(name: 'test_name', schema: consumer_schema) }
+    subject(:consumer) { described_class.new(application_name: 'test_name', schema: consumer_schema) }
 
     context 'with identical schemas' do
       let(:consumer_schema) { '{"name":"test","type":"record","fields":[]}' }

--- a/spec/avro_contract_testing/producer_spec.rb
+++ b/spec/avro_contract_testing/producer_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'avro_contract_testing/producer'
+
+describe AvroContractTesting::Producer do
+  describe '#compatible?' do
+    subject(:producer) { described_class.new(application_name: 'test_name', schema: producer_schema) }
+
+    context 'with identical schemas' do
+      let(:producer_schema) { '{"name":"test","type":"record","fields":[]}' }
+      it { is_expected.to be_compatible(producer_schema) }
+    end
+
+    context 'with additional fields on the consumer' do
+      let(:producer_schema) { '{"name":"test","type":"record","fields":[]}' }
+      let(:consumer_schema) { '{"name":"test","type":"record","fields":[{"name":"id","type":"int"}]}' }
+      it { is_expected.not_to be_compatible(consumer_schema) }
+    end
+
+    context 'with additional fields on the producer' do
+      let(:producer_schema) { '{"name":"test","type":"record","fields":[{"name":"id","type":"int"}]}' }
+      let(:consumer_schema) { '{"name":"test","type":"record","fields":[]}' }
+      it { is_expected.to be_compatible(consumer_schema) }
+    end
+  end
+end


### PR DESCRIPTION
This will give us the ability to implement Avro contract tests inside consumers to make sure they do not break the producer.

Other related changes in this PR:

- Change the naming convention for the consumer class. It takes an `application_name` rather than a `name`. I'm hoping this makes the tests a bit clearer (EG `expect(consumer.name).to eq 'test_application'` vs `expect(consumer.application_name).to eq 'test_application'`) 
- Similarly, since the file structure in S3 goes `schema_role/schema_name/application_name`, the name of the helper function that uses regex to parse the app name from the file is changed from `consumer_name` to `application_name`. Also altered the regex to work w/ or w/o a schema role prefix in the filename/folder structure